### PR TITLE
fixed potential future problems

### DIFF
--- a/server/keymap.hpp
+++ b/server/keymap.hpp
@@ -29,7 +29,7 @@ struct KeyEvent {
     SDL::Key key = SDL::K_UNKNOWN;
     uint8_t button = 0;
 
-    bool operator== (const KeyEvent &other) const {
+    static inline bool operator== (const KeyEvent &other) const {
         if (mod != other.mod) return false;
         if (type != other.type) return false;
         switch (type) {
@@ -40,7 +40,7 @@ struct KeyEvent {
         }
     }
 
-    bool operator< (const KeyEvent &other) const {
+    static inline bool operator< (const KeyEvent &other) const {
         if (mod != other.mod) return mod < other.mod;
         if (type != other.type) return type < other.type;
         switch (type) {


### PR DESCRIPTION
if the header is included more than once then function redefinition might be  a problem. static inline is the easy solution tho the proper solution might be to separate into hpp+cpp files. I'd say that static inline is better here since it might get inlined.