### PR TITLE
generic tileset sizes

### DIFF
--- a/static/config.js
+++ b/static/config.js
@@ -14,6 +14,7 @@ var config = {
 	port: '1234',
 	protocol: 'DFPlex-invalid',
 	tiles: "Phoebus.png",
+	size: 16,
 	text: "ShizzleClean.png",
 	overworld: "ShizzleClean.png",
 	nick: "",


### PR DESCRIPTION
Flattened color tilesets (one line instead of a grid)
Added size parameter
Use size of the 3 tilesets images (tiles, text, overworld)

I started from the release, so the original code changed a bit, and I am not sure about these modifications, feel free to close, take what you want from the changes, or ask for other modifications.