### PR TITLE
Fix websocket connection in Chrome

### DIFF
--- a/static/js/dfplex.js
+++ b/static/js/dfplex.js
@@ -140,7 +140,7 @@ function setStatus(text, color, onclick) {
 
 function connect() {
 	setStatus('Connecting...', 'orange');
-	websocket = new WebSocket(wsUri, [protocol, 'DFPlex-invalid']);
+	websocket = new WebSocket(wsUri);
 	websocket.binaryType = 'arraybuffer';
 	websocket.onopen  = onOpen;
 	websocket.onclose = onClose;


### PR DESCRIPTION
Presumably websocketpp needs some manual intervention to send a sec-websocket-protocol response header, and chrome kills the socket if it doesn't see one

Subprotocols are of no use here so the easiest solution is to not use them